### PR TITLE
Use constistently single quotes instead of backticks. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,7 +116,7 @@ module.exports = function (options) {
         for (var i=0; i<entrances.length; i++) {
             parts.push(Buffer(entrances[i].replace(/\n/g, '')));
             if (i < entrances.length - 1) {
-                parts.push(Buffer('`, `));
+                parts.push(Buffer('`, `'));
             }
         }
         parts.push(Buffer('`]'));

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ module.exports = function (options) {
 
         var parts = [];
         parts.push(Buffer(content.substring(0, matches.index)));
-        parts.push(Buffer('styles: [`'));
+        parts.push(Buffer('styles: [\''));
 
         for (var i=0; i<entrances.length; i++) {
             parts.push(Buffer(entrances[i].replace(/\n/g, '')));
@@ -119,7 +119,7 @@ module.exports = function (options) {
                 parts.push(Buffer('\', \''));
             }
         }
-        parts.push(Buffer('`]'));
+        parts.push(Buffer('\']'));
         parts.push(Buffer(content.substr(matches.index + matches[0].length)));
         return Buffer.concat(parts);
     }

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ module.exports = function (options) {
 
             less.render(
               content,
-            
+
             function(err, result) {
                 if (err) {
                     cb(FOUND_ERROR, 'Error while compiling less template "' + path + '". Error from "less" plugin: ' + err);
@@ -111,15 +111,15 @@ module.exports = function (options) {
 
         var parts = [];
         parts.push(Buffer(content.substring(0, matches.index)));
-        parts.push(Buffer('styles: [\''));
+        parts.push(Buffer('styles: [`'));
 
         for (var i=0; i<entrances.length; i++) {
             parts.push(Buffer(entrances[i].replace(/\n/g, '')));
             if (i < entrances.length - 1) {
-                parts.push(Buffer('\', \''));
+                parts.push(Buffer('`, `));
             }
         }
-        parts.push(Buffer('\']'));
+        parts.push(Buffer('`]'));
         parts.push(Buffer(content.substr(matches.index + matches[0].length)));
         return Buffer.concat(parts);
     }

--- a/test/assets/assert.component.ts
+++ b/test/assets/assert.component.ts
@@ -3,7 +3,7 @@ import {Component} from 'angular2/core';
 @Component({
     selector: 'app',
     templateUrl: 'test/assets/test.component.html',
-    styles: [`h1 {  font-size: 200px; }', 'h5 {  color: red; }  h5 .title {    color: blue; }`]
+    styles: [`h1 {  font-size: 200px; }`, `h5 {  color: red; }  h5 .title {    color: blue; }`]
 })
 
 export class AppComponent { }

--- a/test/assets/assertless.component.ts
+++ b/test/assets/assertless.component.ts
@@ -3,7 +3,7 @@ import {Component} from 'angular2/core';
 @Component({
     selector: 'app',
     templateUrl: 'test/assets/test.component.html',
-    styles: [`h1 {  font-size: 200px;}', 'h5 {  color: red;}h5 .title {  color: blue;}`]
+    styles: [`h1 {  font-size: 200px;}`, `h5 {  color: red;}h5 .title {  color: blue;}`]
 })
 
 export class AppComponent { }


### PR DESCRIPTION
This way won't break styles if multiple styleUrls were added to the input.
The loop part of `joinParts` used already single quotes.